### PR TITLE
Set default value in dbconfig to be Development

### DIFF
--- a/Infrastructure/Persistance/PersistanceConfiguration.cs
+++ b/Infrastructure/Persistance/PersistanceConfiguration.cs
@@ -17,6 +17,10 @@ namespace Infrastructure.Persistance
             string dbString = dbtype.ToString();
 
             var binpath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if(string.IsNullOrWhiteSpace(environmentName))
+            {
+                environmentName = "Development";
+            }
 
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(binpath)


### PR DESCRIPTION
not everyone has the environmentvalue set to develop, so if the value is not sat, it defaults to "Development"